### PR TITLE
fixed re-render for change props.url

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,7 @@ export class PDFObject extends React.PureComponent<Props> {
     assumptionMode: true,
   };
 
-  embed = () => {
+  private embed = () => {
     const { url, containerId, containerProps, ...options } = this.props;
     if (pdfobject) {
       pdfobject.embed(url, `#${containerId}`, options);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,11 +42,6 @@ export interface Props {
 }
 
 export class PDFObject extends React.PureComponent<Props> {
-  public constructor(props){
-    super(props);
-    this.embed = this.embed.bind(this);
-  }
-  
   public static defaultProps = {
     width: '100%',
     height: '100%',
@@ -54,8 +49,12 @@ export class PDFObject extends React.PureComponent<Props> {
     forcePDFJS: false,
     assumptionMode: true,
   };
-  
-  public embed(){
+  public constructor(props: Props) {
+    super(props);
+    this.embed = this.embed.bind(this);
+  }
+
+  public embed() {
     const { url, containerId, containerProps, ...options } = this.props;
     if (pdfobject) {
       pdfobject.embed(url, `#${containerId}`, options);
@@ -66,10 +65,10 @@ export class PDFObject extends React.PureComponent<Props> {
     // for the SSR
     this.embed();
   }
-  
-  public componentDidUpdate(prevProps){
-    // check for different props.url 
-    if(prevProps.url !== this.props.url) {
+
+  public componentDidUpdate(prevProps: Props) {
+    // check for different props.url
+    if (prevProps.url !== this.props.url) {
       this.embed();
     }
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,13 +49,26 @@ export class PDFObject extends React.PureComponent<Props> {
     forcePDFJS: false,
     assumptionMode: true,
   };
+  
+  public embed(){
+    if (pdfobject) {
+      pdfobject.embed(url, `#${containerId}`, options);
+    }
+  }
 
   public componentDidMount() {
     const { url, containerId, containerProps, ...options } = this.props;
 
     // for the SSR
-    if (pdfobject) {
-      pdfobject.embed(url, `#${containerId}`, options);
+    this.embed()
+  }
+  
+  public componentDidUpdate(prevProps){
+    const { url, containerId, containerProps, ...options } = this.props;
+    
+    // check for different props.url 
+    if(prevProps.url !== this.props.url) {
+      this.embed()
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,12 +49,8 @@ export class PDFObject extends React.PureComponent<Props> {
     forcePDFJS: false,
     assumptionMode: true,
   };
-  public constructor(props: Props) {
-    super(props);
-    this.embed = this.embed.bind(this);
-  }
 
-  public embed() {
+  embed = () => {
     const { url, containerId, containerProps, ...options } = this.props;
     if (pdfobject) {
       pdfobject.embed(url, `#${containerId}`, options);
@@ -62,7 +58,6 @@ export class PDFObject extends React.PureComponent<Props> {
   }
 
   public componentDidMount() {
-    // for the SSR
     this.embed();
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,11 @@ export interface Props {
 }
 
 export class PDFObject extends React.PureComponent<Props> {
+  public constructor(props){
+    super(props);
+    this.embed = this.embed.bind(this);
+  }
+  
   public static defaultProps = {
     width: '100%',
     height: '100%',
@@ -51,24 +56,21 @@ export class PDFObject extends React.PureComponent<Props> {
   };
   
   public embed(){
+    const { url, containerId, containerProps, ...options } = this.props;
     if (pdfobject) {
       pdfobject.embed(url, `#${containerId}`, options);
     }
   }
 
   public componentDidMount() {
-    const { url, containerId, containerProps, ...options } = this.props;
-
     // for the SSR
-    this.embed()
+    this.embed();
   }
   
   public componentDidUpdate(prevProps){
-    const { url, containerId, containerProps, ...options } = this.props;
-    
     // check for different props.url 
     if(prevProps.url !== this.props.url) {
-      this.embed()
+      this.embed();
     }
   }
 


### PR DESCRIPTION
Hi @sugarshin,

I've been use your library `sugarshin/react-pdfobject`

When `url` in props has change from a parent of `react-pdfobject`, `react-pdfobject` not rerender of changed URL.

This is a step of my issue:
```
setState({url: 'x.pdf'})
<PDFObject url={state.url} />
// when change state of url
setState({url: 'y.pdf'})
// PDFObject no re-render when url props has changed
```

This is my pull request, We need to review  (CMIIW)

seems related with this is issue https://github.com/sugarshin/react-pdfobject/issues/37 
regards,
- ri7nz 👍 💯 